### PR TITLE
ci: restrict GITHUB_TOKEN permissions in Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,7 @@
 name: Go
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Summary
Adds a top-level `permissions: contents: read` block to `.github/workflows/go.yml`.

The `build` job only checks out code, installs Go tooling, builds, and runs tests — none of which need write access. Without an explicit block, `GITHUB_TOKEN` gets the repository's default (often broad) scopes.

## Why
Resolves open code-scanning alert [#1](https://github.com/lelledev/upaygo/security/code-scanning/1) — `actions/missing-workflow-permissions` (medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to establish explicit repository access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->