### PR TITLE
Migrate stripe-go legacy resource APIs to stripe.Client (#51)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,6 +40,18 @@ jobs:
       - name: Build
         run: go build -v .
 
+      - name: Guard - no legacy stripe resource APIs
+        run: |
+          set -e
+          if grep -R --include='*.go' -n 'stripe\.Key\s*=' . --exclude-dir=vendor; then
+            echo "stripe.Key assignment is forbidden; use appconfig.ClientForCurrency / stripe.NewClient"
+            exit 1
+          fi
+          if grep -R --include='*.go' -nE 'github.com/stripe/stripe-go/v82/(paymentintent|customer)"' . --exclude-dir=vendor; then
+            echo "legacy paymentintent/customer packages must not be imported; use stripe.Client services"
+            exit 1
+          fi
+
       - name: Tests - Unit
         run: go test ./... -failfast -tags=unit
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Payment Gateway Microservice in Golang
         - Capture/Delete intent
 - No database infrastructure needed
 - Stripe API keys configuration per currency
+- Stripe access via `stripe.Client` (`appconfig.ClientForCurrency`) — no global `stripe.Key`
 
 ## Installation
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -134,3 +134,38 @@ func TestServerConfig(t *testing.T) {
 		t.Errorf("incorrect server config URI, got: %v want: %v", got.GetURI(), "https://localhost:8080")
 	}
 }
+
+func TestClientForCurrency(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	sc, e := appconfig.ClientForCurrency("EUR")
+	if e != nil {
+		t.Errorf("error creating Stripe client for EUR: %v", e)
+	}
+	if sc == nil {
+		t.Error("expected a non-nil Stripe client for EUR")
+	}
+
+	sc, e = appconfig.ClientForCurrency("NOT_FOUND_CURRENCY")
+	if e != nil {
+		t.Errorf("error creating Stripe client for default currency: %v", e)
+	}
+	if sc == nil {
+		t.Error("expected a non-nil Stripe client for default currency")
+	}
+}
+
+func TestClientForCurrencyWithoutDefault(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithoutDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	_, e = appconfig.ClientForCurrency("NOT_FOUND_CURRENCY")
+	if e == nil {
+		t.Error("configuration without Stripe default API keys must return an error")
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -169,3 +169,18 @@ func TestClientForCurrencyWithoutDefault(t *testing.T) {
 		t.Error("configuration without Stripe default API keys must return an error")
 	}
 }
+
+func TestClientForCurrencyOpWithoutDefault(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithoutDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	_, e = appconfig.ClientForCurrencyOp("NOT_FOUND_CURRENCY", "payment intent capture")
+	if e == nil {
+		t.Error("configuration without Stripe default API keys must return an error")
+	}
+	if e != nil && !strings.Contains(e.Error(), "payment intent capture") {
+		t.Errorf("operation context missing from error, got: %v", e)
+	}
+}

--- a/config/stripe_client.go
+++ b/config/stripe_client.go
@@ -1,0 +1,16 @@
+package appconfig
+
+import "github.com/stripe/stripe-go/v82"
+
+// ClientForCurrency returns a stripe.Client authenticated with the secret key
+// configured for iso4217 (or the default key if the currency is not listed).
+// Prefer this over a package-level global secret so concurrent requests with
+// different currencies do not race on shared API credentials.
+func ClientForCurrency(iso4217 string) (*stripe.Client, error) {
+	cfg, err := GetStripeAPIConfigByCurrency(iso4217)
+	if err != nil {
+		return nil, err
+	}
+
+	return stripe.NewClient(cfg.GetSK()), nil
+}

--- a/config/stripe_client.go
+++ b/config/stripe_client.go
@@ -18,3 +18,13 @@ func ClientForCurrency(iso4217 string) (*stripe.Client, error) {
 
 	return stripe.NewClient(cfg.GetSK()), nil
 }
+
+// ClientForCurrencyOp is like ClientForCurrency but wraps lookup failures with
+// an operation name for clearer call-site diagnostics.
+func ClientForCurrencyOp(iso4217, op string) (*stripe.Client, error) {
+	sc, err := ClientForCurrency(iso4217)
+	if err != nil {
+		return nil, fmt.Errorf("create Stripe client for %s currency %q: %w", op, iso4217, err)
+	}
+	return sc, nil
+}

--- a/config/stripe_client.go
+++ b/config/stripe_client.go
@@ -1,6 +1,10 @@
 package appconfig
 
-import "github.com/stripe/stripe-go/v82"
+import (
+	"fmt"
+
+	"github.com/stripe/stripe-go/v82"
+)
 
 // ClientForCurrency returns a stripe.Client authenticated with the secret key
 // configured for iso4217 (or the default key if the currency is not listed).
@@ -9,7 +13,7 @@ import "github.com/stripe/stripe-go/v82"
 func ClientForCurrency(iso4217 string) (*stripe.Client, error) {
 	cfg, err := GetStripeAPIConfigByCurrency(iso4217)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load Stripe configuration for %q: %w", iso4217, err)
 	}
 
 	return stripe.NewClient(cfg.GetSK()), nil

--- a/controller/rest/intent/cancel/restintentcancel_integration_test.go
+++ b/controller/rest/intent/cancel/restintentcancel_integration_test.go
@@ -81,23 +81,25 @@ func createTestIntent() (string, error) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+		return "", fmt.Errorf("create Stripe client: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("create test payment intent: %w", e)
 	}
 
-	return intent.ID, e
+	return intent.ID, nil
 }
 
 // Test a create intent request
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+
+	// Handler under test cancels the intent; no teardown cancel (already canceled).
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -109,14 +111,14 @@ func Test(t *testing.T) {
 	res := w.Result()
 	resBody, e := io.ReadAll(res.Body)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 	defer res.Body.Close()
 
 	var resI responseIntent
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {
@@ -126,11 +128,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "canceled" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'canceled'")
 	}
-
-	sc, e := appconfig.ClientForCurrency("EUR")
-	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
-		return
-	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/cancel/restintentcancel_integration_test.go
+++ b/controller/rest/intent/cancel/restintentcancel_integration_test.go
@@ -4,6 +4,7 @@
 package apprestintentcancel_test
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,12 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -125,5 +127,10 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'canceled'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	sc, e := appconfig.ClientForCurrency("EUR")
+	if e != nil {
+		t.Errorf(errorRestCreateIntent, e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/capture/restintentcapture_integration_test.go
+++ b/controller/rest/intent/capture/restintentcapture_integration_test.go
@@ -81,23 +81,25 @@ func createTestIntent() (string, error) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+		return "", fmt.Errorf("create Stripe client: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("create test payment intent: %w", e)
 	}
 
-	return intent.ID, e
+	return intent.ID, nil
 }
 
 // Test a create intent request
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+
+	// Succeeded PaymentIntents cannot be cancelled after a successful capture.
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -109,14 +111,14 @@ func Test(t *testing.T) {
 	res := w.Result()
 	resBody, e := io.ReadAll(res.Body)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 	defer res.Body.Close()
 
 	var resI responseIntent
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {
@@ -126,11 +128,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "succeeded" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'succeeded'")
 	}
-
-	sc, e := appconfig.ClientForCurrency("EUR")
-	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
-		return
-	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/capture/restintentcapture_integration_test.go
+++ b/controller/rest/intent/capture/restintentcapture_integration_test.go
@@ -4,6 +4,7 @@
 package apprestintentcapture_test
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(1179)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,12 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -125,5 +127,10 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'succeeded'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	sc, e := appconfig.ClientForCurrency("EUR")
+	if e != nil {
+		t.Errorf(errorRestCreateIntent, e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/confirm/restintentconfirm_integration_test.go
+++ b/controller/rest/intent/confirm/restintentconfirm_integration_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func createTestIntent() (string, error) {
+func createTestIntent() (string, *stripe.Client, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
 	pip := &stripe.PaymentIntentCreateParams{
@@ -80,23 +80,29 @@ func createTestIntent() (string, error) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+		return "", nil, fmt.Errorf("create Stripe client: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", nil, fmt.Errorf("create test payment intent: %w", e)
 	}
 
-	return intent.ID, e
+	return intent.ID, sc, nil
 }
 
 // Test a create intent request
 func Test(t *testing.T) {
-	intentID, e := createTestIntent()
+	intentID, sc, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intentID, err)
+		}
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -108,14 +114,14 @@ func Test(t *testing.T) {
 	res := w.Result()
 	resBody, e := io.ReadAll(res.Body)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 	defer res.Body.Close()
 
 	var resI responseIntent
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {
@@ -125,11 +131,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "requires_capture" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status as 'requires_capture'")
 	}
-
-	sc, e := appconfig.ClientForCurrency("EUR")
-	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
-		return
-	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/confirm/restintentconfirm_integration_test.go
+++ b/controller/rest/intent/confirm/restintentconfirm_integration_test.go
@@ -4,6 +4,7 @@
 package apprestintentconfirm_test
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -78,10 +78,12 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -124,5 +126,10 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status as 'requires_capture'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	sc, e := appconfig.ClientForCurrency("EUR")
+	if e != nil {
+		t.Errorf(errorRestCreateIntent, e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -4,6 +4,7 @@
 package apprestintentcreate_test
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -13,8 +14,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/stripe/stripe-go/v82/customer"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	apprestintentcreate "github.com/lelledev/upaygo/controller/rest/intent/create"
@@ -98,7 +97,12 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the customer reference")
 	}
 
-	_, _ = customer.Del(cus.GetGatewayReference(), nil)
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	if e != nil {
+		t.Errorf(errorRestCreateIntent, e)
+		return
+	}
+	_, _ = sc.V1Customers.Delete(context.Background(), cus.GetGatewayReference(), nil)
 }
 
 // Test a create intent request without customer

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -67,8 +67,19 @@ func Test(t *testing.T) {
 	c, _ := appcurrency.New("EUR")
 	cus, e := appcustomer.NewStripe("email@email.com", c)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
+
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	if e != nil {
+		t.Fatalf(errorRestCreateIntent, e)
+	}
+	customerID := cus.GetGatewayReference()
+	t.Cleanup(func() {
+		if _, err := sc.V1Customers.Delete(context.Background(), customerID, nil); err != nil {
+			t.Errorf("cleanup delete customer %s: %v", customerID, err)
+		}
+	})
 
 	a, ps, w := 7777, "pm_card_visa", httptest.NewRecorder()
 	p := fmt.Sprintf("currency=%v&amount=%v&payment_source=%v&customer_reference=%v", c.GetISO4217(), a, ps, cus.GetGatewayReference())
@@ -80,13 +91,13 @@ func Test(t *testing.T) {
 	res := w.Result()
 	resBody, e := io.ReadAll(res.Body)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 	defer res.Body.Close()
 
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {
@@ -96,13 +107,6 @@ func Test(t *testing.T) {
 	if resI.Customer.R == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the customer reference")
 	}
-
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
-	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
-		return
-	}
-	_, _ = sc.V1Customers.Delete(context.Background(), cus.GetGatewayReference(), nil)
 }
 
 // Test a create intent request without customer
@@ -121,12 +125,12 @@ func TestWithoutCustomer(t *testing.T) {
 	resBody, e := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -65,15 +65,17 @@ func Test(t *testing.T) {
 	var resI responseIntent
 
 	c, _ := appcurrency.New("EUR")
-	cus, e := appcustomer.NewStripe("email@email.com", c)
-	if e != nil {
-		t.Fatalf(errorRestCreateIntent, e)
-	}
 
 	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
 	if e != nil {
 		t.Fatalf(errorRestCreateIntent, e)
 	}
+
+	cus, e := appcustomer.NewStripe("email@email.com", c)
+	if e != nil {
+		t.Fatalf(errorRestCreateIntent, e)
+	}
+
 	customerID := cus.GetGatewayReference()
 	t.Cleanup(func() {
 		if _, err := sc.V1Customers.Delete(context.Background(), customerID, nil); err != nil {

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -19,6 +19,7 @@ import (
 	apprestintentcreate "github.com/lelledev/upaygo/controller/rest/intent/create"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	"github.com/lelledev/upaygo/internal/stripetest"
 )
 
 const (
@@ -66,10 +67,7 @@ func Test(t *testing.T) {
 
 	c, _ := appcurrency.New("EUR")
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
-	if e != nil {
-		t.Fatalf(errorRestCreateIntent, e)
-	}
+	sc := stripetest.Client(t, c.GetISO4217())
 
 	cus, e := appcustomer.NewStripe("email@email.com", c)
 	if e != nil {

--- a/controller/rest/intent/get/restintentget_integration_test.go
+++ b/controller/rest/intent/get/restintentget_integration_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func createTestIntent() (string, error) {
+func createTestIntent() (string, *stripe.Client, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
 	pip := &stripe.PaymentIntentCreateParams{
@@ -81,23 +81,29 @@ func createTestIntent() (string, error) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+		return "", nil, fmt.Errorf("create Stripe client: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", nil, fmt.Errorf("create test payment intent: %w", e)
 	}
 
-	return intent.ID, e
+	return intent.ID, sc, nil
 }
 
 // Test a create intent request
 func Test(t *testing.T) {
-	intentID, e := createTestIntent()
+	intentID, sc, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intentID, err)
+		}
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
@@ -112,24 +118,17 @@ func Test(t *testing.T) {
 	res := w.Result()
 	resBody, e := io.ReadAll(res.Body)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 	defer res.Body.Close()
 
 	var resI responseIntent
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
 
 	if resI.IntentGatewayReference == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
 	}
-
-	sc, e := appconfig.ClientForCurrency("EUR")
-	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
-		return
-	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/controller/rest/intent/get/restintentget_integration_test.go
+++ b/controller/rest/intent/get/restintentget_integration_test.go
@@ -4,6 +4,7 @@
 package apprestintentget_test
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -21,7 +22,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,12 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		return "", fmt.Errorf("impossible to create Stripe client: %v", e)
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -124,5 +126,10 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	sc, e := appconfig.ClientForCurrency("EUR")
+	if e != nil {
+		t.Errorf(errorRestCreateIntent, e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil)
 }

--- a/customer/customerstripe.go
+++ b/customer/customerstripe.go
@@ -1,11 +1,10 @@
 package appcustomer
 
 import (
+	"context"
 	"errors"
 
 	apperror "github.com/lelledev/upaygo/error"
-
-	"github.com/stripe/stripe-go/v82/customer"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,17 +17,15 @@ func NewStripe(email string, ac appcurrency.Currency) (Customer, error) {
 		return nil, errors.New("impossible to create a Stripe customer without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(ac.GetISO4217())
+	sc, e := appconfig.ClientForCurrency(ac.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	params := &stripe.CustomerParams{
+	params := &stripe.CustomerCreateParams{
 		Email: new(email),
 	}
-	cus, e := customer.New(params)
+	cus, e := sc.V1Customers.Create(context.Background(), params)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/customer/customerstripe.go
+++ b/customer/customerstripe.go
@@ -3,7 +3,6 @@ package appcustomer
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	apperror "github.com/lelledev/upaygo/error"
 
@@ -18,9 +17,9 @@ func NewStripe(email string, ac appcurrency.Currency) (Customer, error) {
 		return nil, errors.New("impossible to create a Stripe customer without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(ac.GetISO4217())
+	sc, e := appconfig.ClientForCurrencyOp(ac.GetISO4217(), "customer create")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for customer currency %q: %w", ac.GetISO4217(), e)
+		return nil, e
 	}
 
 	params := &stripe.CustomerCreateParams{

--- a/customer/customerstripe.go
+++ b/customer/customerstripe.go
@@ -3,6 +3,7 @@ package appcustomer
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	apperror "github.com/lelledev/upaygo/error"
 
@@ -19,7 +20,7 @@ func NewStripe(email string, ac appcurrency.Currency) (Customer, error) {
 
 	sc, e := appconfig.ClientForCurrency(ac.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for customer currency %q: %w", ac.GetISO4217(), e)
 	}
 
 	params := &stripe.CustomerCreateParams{

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -4,12 +4,11 @@
 package appcustomer_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/stripe/stripe-go/v82/customer"
 
 	appcurrency "github.com/lelledev/upaygo/currency"
 
@@ -60,5 +59,10 @@ func TestNewStripe(t *testing.T) {
 		t.Errorf("The new customer.email is incorrect, got: %v want %v", got.GetEmail(), email)
 	}
 
-	_, _ = customer.Del(got.GetGatewayReference(), nil)
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
+		return
+	}
+	_, _ = sc.V1Customers.Delete(context.Background(), got.GetGatewayReference(), nil)
 }

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -46,15 +46,16 @@ func TestNewStripe(t *testing.T) {
 	email := "email@email.com"
 	c, _ := appcurrency.New("EUR")
 
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	if e != nil {
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
+	}
+
 	got, e := appcustomer.NewStripe(email, c)
 	if e != nil {
 		t.Fatalf("error during the appcustomer creation with Stripe: %v", e)
 	}
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
-	}
 	customerID := got.GetGatewayReference()
 	t.Cleanup(func() {
 		if _, err := sc.V1Customers.Delete(context.Background(), customerID, nil); err != nil {

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	"github.com/lelledev/upaygo/internal/stripetest"
 )
 
 func TestMain(m *testing.M) {
@@ -46,10 +47,7 @@ func TestNewStripe(t *testing.T) {
 	email := "email@email.com"
 	c, _ := appcurrency.New("EUR")
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
-	}
+	sc := stripetest.Client(t, c.GetISO4217())
 
 	got, e := appcustomer.NewStripe(email, c)
 	if e != nil {

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -48,21 +48,25 @@ func TestNewStripe(t *testing.T) {
 
 	got, e := appcustomer.NewStripe(email, c)
 	if e != nil {
-		t.Errorf("error during the appcustomer creation with Stripe: %v", e)
+		t.Fatalf("error during the appcustomer creation with Stripe: %v", e)
 	}
 
-	if got.GetGatewayReference() == "" {
-		t.Errorf("The new customer.gateway_reference is empty, got: %v", got.GetGatewayReference())
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	if e != nil {
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
+	}
+	customerID := got.GetGatewayReference()
+	t.Cleanup(func() {
+		if _, err := sc.V1Customers.Delete(context.Background(), customerID, nil); err != nil {
+			t.Errorf("cleanup delete customer %s: %v", customerID, err)
+		}
+	})
+
+	if customerID == "" {
+		t.Errorf("The new customer.gateway_reference is empty, got: %v", customerID)
 	}
 
 	if got.GetEmail() != email {
 		t.Errorf("The new customer.email is incorrect, got: %v want %v", got.GetEmail(), email)
 	}
-
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
-	if e != nil {
-		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
-		return
-	}
-	_, _ = sc.V1Customers.Delete(context.Background(), got.GetGatewayReference(), nil)
 }

--- a/internal/stripetest/client.go
+++ b/internal/stripetest/client.go
@@ -1,0 +1,21 @@
+package stripetest
+
+import (
+	"testing"
+
+	appconfig "github.com/lelledev/upaygo/config"
+
+	"github.com/stripe/stripe-go/v82"
+)
+
+// Client returns a *stripe.Client for iso4217, or fatals the test.
+// Use this in Stripe integration tests when obtaining a client for fixtures
+// or t.Cleanup so the error handling stays consistent.
+func Client(t *testing.T, iso4217 string) *stripe.Client {
+	t.Helper()
+	sc, err := appconfig.ClientForCurrency(iso4217)
+	if err != nil {
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", err)
+	}
+	return sc
+}

--- a/payment/intent/cancel/intentcancel.go
+++ b/payment/intent/cancel/intentcancel.go
@@ -3,6 +3,7 @@ package apppaymentintentcancel
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -16,9 +17,10 @@ func Cancel(id string, c appcurrency.Currency) (apppaymentintent.Intent, error) 
 		return nil, errors.New("impossible to cancel the payment intent without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	currency := c.GetISO4217()
+	sc, e := appconfig.ClientForCurrency(currency)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for payment intent cancel currency %q: %w", currency, e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Cancel(context.Background(), id, nil)

--- a/payment/intent/cancel/intentcancel.go
+++ b/payment/intent/cancel/intentcancel.go
@@ -1,15 +1,13 @@
 package apppaymentintentcancel
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Cancel gets the intent id from c Stripe account and cancel it
@@ -18,14 +16,12 @@ func Cancel(id string, c appcurrency.Currency) (apppaymentintent.Intent, error) 
 		return nil, errors.New("impossible to cancel the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Cancel(id, nil)
+	intent, e := sc.V1PaymentIntents.Cancel(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/cancel/intentcancel.go
+++ b/payment/intent/cancel/intentcancel.go
@@ -3,7 +3,6 @@ package apppaymentintentcancel
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -17,10 +16,9 @@ func Cancel(id string, c appcurrency.Currency) (apppaymentintent.Intent, error) 
 		return nil, errors.New("impossible to cancel the payment intent without required parameters")
 	}
 
-	currency := c.GetISO4217()
-	sc, e := appconfig.ClientForCurrency(currency)
+	sc, e := appconfig.ClientForCurrencyOp(c.GetISO4217(), "payment intent cancel")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for payment intent cancel currency %q: %w", currency, e)
+		return nil, e
 	}
 
 	intent, e := sc.V1PaymentIntents.Cancel(context.Background(), id, nil)

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -70,6 +70,12 @@ func TestCancel(t *testing.T) {
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
+		// Cancel failed — still cancelable; clean up the fixture.
+		t.Cleanup(func() {
+			if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+				t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+			}
+		})
 		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
@@ -105,6 +111,11 @@ func TestCancelWithSCACard(t *testing.T) {
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
+		t.Cleanup(func() {
+			if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+				t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+			}
+		})
 		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
@@ -140,6 +151,11 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
+		t.Cleanup(func() {
+			if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+				t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+			}
+		})
 		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -4,6 +4,7 @@
 package apppaymentintentcancel_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -14,7 +15,6 @@ import (
 	apppaymentintentcancel "github.com/lelledev/upaygo/payment/intent/cancel"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestCancel(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -58,10 +58,13 @@ func TestCancel(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -79,7 +82,7 @@ func TestCancel(t *testing.T) {
 func TestCancelWithSCACard(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -91,10 +94,13 @@ func TestCancelWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -112,7 +118,7 @@ func TestCancelWithSCACard(t *testing.T) {
 func TestCancelNonConfirmedIntent(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("manual"),
@@ -124,10 +130,13 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	"github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcancel "github.com/lelledev/upaygo/payment/intent/cancel"
 
 	"github.com/stripe/stripe-go/v82"
@@ -58,10 +59,7 @@ func TestCancel(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
@@ -99,10 +97,7 @@ func TestCancelWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
@@ -139,10 +134,7 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -60,18 +60,17 @@ func TestCancel(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {
@@ -96,18 +95,17 @@ func TestCancelWithSCACard(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {
@@ -132,18 +130,17 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {

--- a/payment/intent/capture/intentcapture.go
+++ b/payment/intent/capture/intentcapture.go
@@ -3,7 +3,6 @@ package apppaymentintentcapture
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -17,10 +16,9 @@ func Capture(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to capture the payment intent without required parameters")
 	}
 
-	currency := c.GetISO4217()
-	sc, e := appconfig.ClientForCurrency(currency)
+	sc, e := appconfig.ClientForCurrencyOp(c.GetISO4217(), "payment intent capture")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for payment intent capture currency %q: %w", currency, e)
+		return nil, e
 	}
 
 	intent, e := sc.V1PaymentIntents.Capture(context.Background(), id, nil)

--- a/payment/intent/capture/intentcapture.go
+++ b/payment/intent/capture/intentcapture.go
@@ -1,15 +1,13 @@
 package apppaymentintentcapture
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Capture gets the intent id from c Stripe account and capture it
@@ -18,14 +16,12 @@ func Capture(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to capture the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Capture(id, nil)
+	intent, e := sc.V1PaymentIntents.Capture(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/capture/intentcapture.go
+++ b/payment/intent/capture/intentcapture.go
@@ -3,6 +3,7 @@ package apppaymentintentcapture
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -16,9 +17,10 @@ func Capture(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to capture the payment intent without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	currency := c.GetISO4217()
+	sc, e := appconfig.ClientForCurrency(currency)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for payment intent capture currency %q: %w", currency, e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Capture(context.Background(), id, nil)

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -60,25 +60,30 @@ func TestCapture(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+
+	// Succeeded PaymentIntents cannot be cancelled; no teardown cancel after capture.
 
 	appintent, e := apppaymentintentcapture.Capture(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to capture %v payment intent: %v", intent.ID, e)
+		// Capture failed — intent may still be cancelable (e.g. requires_capture).
+		t.Cleanup(func() {
+			if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+				t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+			}
+		})
+		t.Fatalf("impossible to capture %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsSucceeded() {
 		t.Error("intent capture is incorrect, got an intent that is not succeeded")
 	}
-
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestCaptureWithSCACard(t *testing.T) {
@@ -98,21 +103,24 @@ func TestCaptureWithSCACard(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+		}
+	})
 
 	_, e = apppaymentintentcapture.Capture(intent.ID, cur)
 	if e == nil {
 		t.Errorf("intent %v should not be captured as it should have status requires_action", intent.ID)
 	}
-
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil)
 }
 
 func TestCaptureWithoutID(t *testing.T) {

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	"github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcapture "github.com/lelledev/upaygo/payment/intent/capture"
 
 	"github.com/stripe/stripe-go/v82"
@@ -58,10 +59,7 @@ func TestCapture(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
@@ -101,10 +99,7 @@ func TestCaptureWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -4,6 +4,7 @@
 package apppaymentintentcapture_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -14,7 +15,6 @@ import (
 	apppaymentintentcapture "github.com/lelledev/upaygo/payment/intent/capture"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestCapture(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -58,10 +58,13 @@ func TestCapture(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -75,13 +78,13 @@ func TestCapture(t *testing.T) {
 		t.Error("intent capture is incorrect, got an intent that is not succeeded")
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestCaptureWithSCACard(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -93,10 +96,13 @@ func TestCaptureWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -106,7 +112,7 @@ func TestCaptureWithSCACard(t *testing.T) {
 		t.Errorf("intent %v should not be captured as it should have status requires_action", intent.ID)
 	}
 
-	_, _ = paymentintent.Cancel(intent.ID, nil)
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil)
 }
 
 func TestCaptureWithoutID(t *testing.T) {

--- a/payment/intent/confirm/intentconfirm.go
+++ b/payment/intent/confirm/intentconfirm.go
@@ -3,6 +3,7 @@ package apppaymentintentconfirm
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -16,9 +17,10 @@ func Confirm(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to confirm the payment intent without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	currency := c.GetISO4217()
+	sc, e := appconfig.ClientForCurrency(currency)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for payment intent confirm currency %q: %w", currency, e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Confirm(context.Background(), id, nil)

--- a/payment/intent/confirm/intentconfirm.go
+++ b/payment/intent/confirm/intentconfirm.go
@@ -1,15 +1,13 @@
 package apppaymentintentconfirm
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Confirm gets the intent id from c Stripe account and confirm it
@@ -18,14 +16,12 @@ func Confirm(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to confirm the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Confirm(id, nil)
+	intent, e := sc.V1PaymentIntents.Confirm(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/confirm/intentconfirm.go
+++ b/payment/intent/confirm/intentconfirm.go
@@ -3,7 +3,6 @@ package apppaymentintentconfirm
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -17,10 +16,9 @@ func Confirm(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to confirm the payment intent without required parameters")
 	}
 
-	currency := c.GetISO4217()
-	sc, e := appconfig.ClientForCurrency(currency)
+	sc, e := appconfig.ClientForCurrencyOp(c.GetISO4217(), "payment intent confirm")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for payment intent confirm currency %q: %w", currency, e)
+		return nil, e
 	}
 
 	intent, e := sc.V1PaymentIntents.Confirm(context.Background(), id, nil)

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -50,6 +50,7 @@ func TestConfirm(t *testing.T) {
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("manual"),
+		CaptureMethod:      new("manual"),
 		PaymentMethod:      new("pm_card_visa"),
 		// payment_method_types is compatible with confirmation_method;
 		// automatic_payment_methods is not (Stripe rejects both together).
@@ -58,25 +59,28 @@ func TestConfirm(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+		}
+	})
 
 	appintent, e := apppaymentintentconfirm.Confirm(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to confirm %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to confirm %v payment intent: %v", intent.ID, e)
 	}
 
 	if appintent.RequiresConfirmation() {
 		t.Error("intent confirmation is incorrect, got an intent that requires confirmation")
 	}
-
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestConfirmWithoutID(t *testing.T) {

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	"github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentconfirm "github.com/lelledev/upaygo/payment/intent/confirm"
 
 	"github.com/stripe/stripe-go/v82"
@@ -57,10 +58,7 @@ func TestConfirm(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -4,6 +4,7 @@
 package apppaymentintentconfirm_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -14,7 +15,6 @@ import (
 	apppaymentintentconfirm "github.com/lelledev/upaygo/payment/intent/confirm"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestConfirm(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("manual"),
@@ -56,10 +56,13 @@ func TestConfirm(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -73,7 +76,7 @@ func TestConfirm(t *testing.T) {
 		t.Error("intent confirmation is incorrect, got an intent that requires confirmation")
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestConfirmWithoutID(t *testing.T) {

--- a/payment/intent/create/intentcreate.go
+++ b/payment/intent/create/intentcreate.go
@@ -3,7 +3,6 @@ package apppaymentintentcreate
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appamount "github.com/lelledev/upaygo/amount"
 	appconfig "github.com/lelledev/upaygo/config"
@@ -22,9 +21,9 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 	}
 
 	currency := a.GetCurrency().GetISO4217()
-	sc, e := appconfig.ClientForCurrency(currency)
+	sc, e := appconfig.ClientForCurrencyOp(currency, "payment intent create")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for payment intent create currency %q: %w", currency, e)
+		return nil, e
 	}
 
 	ic := &stripe.PaymentIntentCreateParams{

--- a/payment/intent/create/intentcreate.go
+++ b/payment/intent/create/intentcreate.go
@@ -3,6 +3,7 @@ package apppaymentintentcreate
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appamount "github.com/lelledev/upaygo/amount"
 	appconfig "github.com/lelledev/upaygo/config"
@@ -20,14 +21,15 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 		return nil, errors.New("impossible to create a payment intent without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(a.GetCurrency().GetISO4217())
+	currency := a.GetCurrency().GetISO4217()
+	sc, e := appconfig.ClientForCurrency(currency)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for payment intent create currency %q: %w", currency, e)
 	}
 
 	ic := &stripe.PaymentIntentCreateParams{
 		Amount:             new(int64(a.GetAmount())),
-		Currency:           new(a.GetCurrency().GetISO4217()),
+		Currency:           new(currency),
 		PaymentMethod:      new(p.GetGatewayReference()),
 		SetupFutureUsage:   new("off_session"),
 		ConfirmationMethod: new("manual"),

--- a/payment/intent/create/intentcreate.go
+++ b/payment/intent/create/intentcreate.go
@@ -1,6 +1,7 @@
 package apppaymentintentcreate
 
 import (
+	"context"
 	"errors"
 
 	appamount "github.com/lelledev/upaygo/amount"
@@ -11,7 +12,6 @@ import (
 	apppaymentsource "github.com/lelledev/upaygo/payment/source"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Create creates an intent in Stripe and returns it as an instance of Intent
@@ -20,14 +20,12 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 		return nil, errors.New("impossible to create a payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(a.GetCurrency().GetISO4217())
+	sc, e := appconfig.ClientForCurrency(a.GetCurrency().GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	ic := &stripe.PaymentIntentParams{
+	ic := &stripe.PaymentIntentCreateParams{
 		Amount:             new(int64(a.GetAmount())),
 		Currency:           new(a.GetCurrency().GetISO4217()),
 		PaymentMethod:      new(p.GetGatewayReference()),
@@ -46,7 +44,7 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 		ic.Customer = new(c.GetGatewayReference())
 	}
 
-	intent, e := paymentintent.New(ic)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), ic)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -47,16 +47,41 @@ func TestMain(m *testing.M) {
 func TestCreate(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := 2045
-	cus, _ := appcustomer.NewStripe("email@email.com", cur)
+	cus, e := appcustomer.NewStripe("email@email.com", cur)
+	if e != nil {
+		t.Fatalf("impossible to create a customer for testing: %v", e)
+	}
+
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
+	}
+
+	// Register customer delete first so LIFO cleanup cancels the intent before
+	// deleting the customer.
+	customerID := cus.GetGatewayReference()
+	t.Cleanup(func() {
+		if _, err := sc.V1Customers.Delete(context.Background(), customerID, nil); err != nil {
+			t.Errorf("cleanup delete customer %s: %v", customerID, err)
+		}
+	})
+
 	a, _ := appamount.New(am, cur.GetISO4217())
 	ps := apppaymentsource.New("pm_card_visa")
 
 	pi, e := apppaymentintentcreate.Create(a, ps, cus)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent: %v", e)
+		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
 
-	if pi.GetGatewayReference() == "" {
+	intentID := pi.GetGatewayReference()
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intentID, err)
+		}
+	})
+
+	if intentID == "" {
 		t.Error("intent new is incorrect, created an intent without gateway reference")
 	}
 
@@ -103,14 +128,6 @@ func TestCreate(t *testing.T) {
 	if !pi.RequiresConfirmation() {
 		t.Error("a new intent should require confirmation")
 	}
-
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
-		return
-	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), pi.GetGatewayReference(), nil)
-	_, _ = sc.V1Customers.Delete(context.Background(), cus.GetGatewayReference(), nil)
 }
 
 func TestCreateWithoutCustomer(t *testing.T) {
@@ -121,19 +138,23 @@ func TestCreateWithoutCustomer(t *testing.T) {
 
 	pi, e := apppaymentintentcreate.Create(a, ps, nil)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent: %v", e)
-	}
-
-	if pi.GetCustomer() != nil {
-		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())
+		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
 	}
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), pi.GetGatewayReference(), nil)
+	intentID := pi.GetGatewayReference()
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intentID, err)
+		}
+	})
+
+	if pi.GetCustomer() != nil {
+		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())
+	}
 }
 
 func TestCreateWithoutAmount(t *testing.T) {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -47,14 +47,17 @@ func TestMain(m *testing.M) {
 func TestCreate(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := 2045
-	cus, e := appcustomer.NewStripe("email@email.com", cur)
-	if e != nil {
-		t.Fatalf("impossible to create a customer for testing: %v", e)
-	}
 
+	// Obtain cleanup client before creating Stripe resources so a client
+	// failure cannot leave them dangling without a registered t.Cleanup.
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
 		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
+	}
+
+	cus, e := appcustomer.NewStripe("email@email.com", cur)
+	if e != nil {
+		t.Fatalf("impossible to create a customer for testing: %v", e)
 	}
 
 	// Register customer delete first so LIFO cleanup cancels the intent before
@@ -136,15 +139,16 @@ func TestCreateWithoutCustomer(t *testing.T) {
 	a, _ := appamount.New(am, cur.GetISO4217())
 	ps := apppaymentsource.New("pm_card_visa")
 
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
+	}
+
 	pi, e := apppaymentintentcreate.Create(a, ps, nil)
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
-	}
 	intentID := pi.GetGatewayReference()
 	t.Cleanup(func() {
 		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intentID, nil); err != nil {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -4,6 +4,7 @@
 package apppaymentintentcreate_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -15,9 +16,6 @@ import (
 	appcustomer "github.com/lelledev/upaygo/customer"
 	apppaymentintentcreate "github.com/lelledev/upaygo/payment/intent/create"
 	apppaymentsource "github.com/lelledev/upaygo/payment/source"
-
-	"github.com/stripe/stripe-go/v82/customer"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -106,8 +104,13 @@ func TestCreate(t *testing.T) {
 		t.Error("a new intent should require confirmation")
 	}
 
-	_, _ = paymentintent.Cancel(pi.GetGatewayReference(), nil)
-	_, _ = customer.Del(cus.GetGatewayReference(), nil)
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), pi.GetGatewayReference(), nil)
+	_, _ = sc.V1Customers.Delete(context.Background(), cus.GetGatewayReference(), nil)
 }
 
 func TestCreateWithoutCustomer(t *testing.T) {
@@ -125,7 +128,12 @@ func TestCreateWithoutCustomer(t *testing.T) {
 		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())
 	}
 
-	_, _ = paymentintent.Cancel(pi.GetGatewayReference(), nil)
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client for cleanup: %v", e)
+		return
+	}
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), pi.GetGatewayReference(), nil)
 }
 
 func TestCreateWithoutAmount(t *testing.T) {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -14,6 +14,7 @@ import (
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	"github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcreate "github.com/lelledev/upaygo/payment/intent/create"
 	apppaymentsource "github.com/lelledev/upaygo/payment/source"
 )
@@ -50,10 +51,7 @@ func TestCreate(t *testing.T) {
 
 	// Obtain cleanup client before creating Stripe resources so a client
 	// failure cannot leave them dangling without a registered t.Cleanup.
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	cus, e := appcustomer.NewStripe("email@email.com", cur)
 	if e != nil {
@@ -139,10 +137,7 @@ func TestCreateWithoutCustomer(t *testing.T) {
 	a, _ := appamount.New(am, cur.GetISO4217())
 	ps := apppaymentsource.New("pm_card_visa")
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client for cleanup: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	pi, e := apppaymentintentcreate.Create(a, ps, nil)
 	if e != nil {

--- a/payment/intent/get/intentget.go
+++ b/payment/intent/get/intentget.go
@@ -3,6 +3,7 @@ package apppaymentintentget
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -16,9 +17,10 @@ func Get(gf string, c appcurrency.Currency) (apppaymentintent.Intent, error) {
 		return nil, errors.New("impossible to get the payment intent without required parameters")
 	}
 
-	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
+	currency := c.GetISO4217()
+	sc, e := appconfig.ClientForCurrency(currency)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("create Stripe client for payment intent get currency %q: %w", currency, e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Retrieve(context.Background(), gf, nil)

--- a/payment/intent/get/intentget.go
+++ b/payment/intent/get/intentget.go
@@ -3,7 +3,6 @@ package apppaymentintentget
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -17,10 +16,9 @@ func Get(gf string, c appcurrency.Currency) (apppaymentintent.Intent, error) {
 		return nil, errors.New("impossible to get the payment intent without required parameters")
 	}
 
-	currency := c.GetISO4217()
-	sc, e := appconfig.ClientForCurrency(currency)
+	sc, e := appconfig.ClientForCurrencyOp(c.GetISO4217(), "payment intent get")
 	if e != nil {
-		return nil, fmt.Errorf("create Stripe client for payment intent get currency %q: %w", currency, e)
+		return nil, e
 	}
 
 	intent, e := sc.V1PaymentIntents.Retrieve(context.Background(), gf, nil)

--- a/payment/intent/get/intentget.go
+++ b/payment/intent/get/intentget.go
@@ -1,15 +1,13 @@
 package apppaymentintentget
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Get gets the gf intent from c Stripe account and returns it as an instance of i
@@ -18,14 +16,12 @@ func Get(gf string, c appcurrency.Currency) (apppaymentintent.Intent, error) {
 		return nil, errors.New("impossible to get the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.ClientForCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Get(gf, nil)
+	intent, e := sc.V1PaymentIntents.Retrieve(context.Background(), gf, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -55,25 +55,28 @@ func TestGet(t *testing.T) {
 
 	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
 	if e != nil {
-		t.Errorf("impossible to create Stripe client: %v", e)
-		return
+		t.Fatalf("impossible to create Stripe client: %v", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+
+	t.Cleanup(func() {
+		if _, err := sc.V1PaymentIntents.Cancel(context.Background(), intent.ID, nil); err != nil {
+			t.Errorf("cleanup cancel payment intent %s: %v", intent.ID, err)
+		}
+	})
 
 	appintent, e := apppaymentintentget.Get(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to get %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to get %v payment intent: %v", intent.ID, e)
 	}
 
 	if appintent.GetGatewayReference() != intent.ID {
 		t.Errorf("intent get is incorrect, got an intent with different ID. Got: %v want: %v", appintent.GetGatewayReference(), intent.ID)
 	}
-
-	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestGetWithoutID(t *testing.T) {

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -4,6 +4,7 @@
 package apppaymentintentget_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -14,7 +15,6 @@ import (
 	apppaymentintentget "github.com/lelledev/upaygo/payment/intent/get"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,17 +46,20 @@ func TestMain(m *testing.M) {
 func TestGet(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:   new(am),
 		Currency: new(cur.GetISO4217()),
 		// Restrict to card so Dashboard redirect methods are not enabled.
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
+	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
+	if e != nil {
+		t.Errorf("impossible to create Stripe client: %v", e)
+		return
+	}
 
-	intent, e := paymentintent.New(pip)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -70,7 +73,7 @@ func TestGet(t *testing.T) {
 		t.Errorf("intent get is incorrect, got an intent with different ID. Got: %v want: %v", appintent.GetGatewayReference(), intent.ID)
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), appintent.GetGatewayReference(), nil)
 }
 
 func TestGetWithoutID(t *testing.T) {

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	"github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentget "github.com/lelledev/upaygo/payment/intent/get"
 
 	"github.com/stripe/stripe-go/v82"
@@ -53,10 +54,7 @@ func TestGet(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sc, e := appconfig.ClientForCurrency(cur.GetISO4217())
-	if e != nil {
-		t.Fatalf("impossible to create Stripe client: %v", e)
-	}
+	sc := stripetest.Client(t, cur.GetISO4217())
 
 	intent, e := sc.V1PaymentIntents.Create(context.Background(), pip)
 	if e != nil {


### PR DESCRIPTION
## Summary

- Migrate production Stripe call sites from deprecated package-level APIs (`paymentintent.*`, `customer.*`) and global `stripe.Key` to `stripe.Client` via `appconfig.ClientForCurrency`.
- Update all Stripe integration tests and fixtures to use `V1PaymentIntents` / `V1Customers` with operation-specific params (`PaymentIntentCreateParams`, `CustomerCreateParams`, etc.).
- Add CI guardrails forbidding `stripe.Key =` assignments and legacy `paymentintent` / `customer` package imports in first-party code.

Fixes concurrent multi-currency secret key races and prepares for a future stripe-go major that removes resource packages. Stays on `stripe-go/v82`.

Closes #51

## Changes

| Area | Change |
|------|--------|
| `config/stripe_client.go` | New `ClientForCurrency(iso4217)` factory |
| Customer + intent create/get/confirm/capture/cancel | Use `sc.V1Customers.*` / `sc.V1PaymentIntents.*` with `context.Background()` |
| Integration tests | Fixtures and cleanup via client APIs (no `stripe.Key`) |
| Unit tests | `ClientForCurrency` success and missing-default cases |
| CI | Grep guard for legacy usage |

## Test plan

- [x] `go test ./... -failfast -tags=unit`
- [x] `go test ./... -failfast -tags=stripe -config=.../config.json` (local)
- [ ] CI green on this branch
- [x] Grep clean: no `stripe.Key =` or legacy resource package imports outside `vendor/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added currency-scoped Stripe client helpers with sensible fallback when currency-specific configuration is missing.
  * Added support for operation-scoped client diagnostics.
* **Bug Fixes**
  * Migrated Stripe payment intent and customer flows to use currency-scoped service clients (removing legacy global key/API usage).
  * Tightened failure handling in integration tests (more fail-fast assertions).
* **Documentation**
  * Updated README “Feature” section to clarify the new Stripe access approach.
* **Tests**
  * Added unit tests for currency-scoped client selection and error messaging.
* **Chores**
  * Added a CI guard to block legacy Stripe resource APIs in Go source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->