### PR TITLE
Migrate from legacy stripe-go resource APIs to stripe.Client

### DIFF
--- a/.github/hooks/gitconfig
+++ b/.github/hooks/gitconfig
@@ -17,7 +17,7 @@
 
 [hook "stripe-legacy-api"]
 	event = pre-commit
-	command = "bash -c 'matches=$(grep -RnE --include=\"*.go\" --exclude-dir=vendor \"stripe\\.Key|stripe-go/v82/(paymentintent|customer)\\b\" . || true); test -z \"$matches\" || { echo \"Legacy stripe-go API usage found, use stripe.Client via appconfig.GetStripeClientByCurrency:\"; echo \"$matches\"; exit 1; }'"
+	command = "bash -c 'matches=$(grep -RnE --include=\"*.go\" --exclude-dir=vendor \"stripe[A-Za-z0-9_]*\\.Key\\b|stripe-go/v82/(paymentintent|customer)\\b\" . || true); test -z \"$matches\" || { echo \"Legacy stripe-go API usage found, use stripe.Client via appconfig.GetStripeClientByCurrency:\"; echo \"$matches\"; exit 1; }'"
 
 [hook "gofmt"]
 	event = pre-commit

--- a/.github/hooks/gitconfig
+++ b/.github/hooks/gitconfig
@@ -17,7 +17,7 @@
 
 [hook "stripe-legacy-api"]
 	event = pre-commit
-	command = "bash -c 'matches=$(grep -RnE --include=\"*.go\" --exclude-dir=vendor \"stripe[A-Za-z0-9_]*\\.Key\\b|stripe-go/v82/(paymentintent|customer)\\b\" . || true); test -z \"$matches\" || { echo \"Legacy stripe-go API usage found, use stripe.Client via appconfig.GetStripeClientByCurrency:\"; echo \"$matches\"; exit 1; }'"
+	command = "bash -c 'status=0; matches=$(grep -RnE --include=\"*.go\" --exclude-dir=vendor \"stripe[A-Za-z0-9_]*\\.Key\\b|stripe-go/v82/(paymentintent|customer)\\b\" .) || status=$?; if [ \"$status\" -gt 1 ]; then echo \"Unable to scan Go sources for legacy stripe-go API usage\"; exit 1; fi; test -z \"$matches\" || { echo \"Legacy stripe-go API usage found, use stripe.Client via appconfig.GetStripeClientByCurrency:\"; echo \"$matches\"; exit 1; }'"
 
 [hook "gofmt"]
 	event = pre-commit

--- a/.github/hooks/gitconfig
+++ b/.github/hooks/gitconfig
@@ -15,6 +15,10 @@
 	event = pre-commit
 	command = "bash -c 'if command -v swag >/dev/null 2>&1; then swag init; else go run github.com/swaggo/swag/cmd/swag@latest init; fi'"
 
+[hook "stripe-legacy-api"]
+	event = pre-commit
+	command = "bash -c 'matches=$(grep -RnE --include=\"*.go\" --exclude-dir=vendor \"stripe\\.Key|stripe-go/v82/(paymentintent|customer)\\b\" . || true); test -z \"$matches\" || { echo \"Legacy stripe-go API usage found, use stripe.Client via appconfig.GetStripeClientByCurrency:\"; echo \"$matches\"; exit 1; }'"
+
 [hook "gofmt"]
 	event = pre-commit
 	command = "bash -c 'files=$(gofmt -l . | grep -v \"^vendor/\" || true); test -z \"$files\" || { echo \"The following files need gofmt:\"; echo \"$files\"; exit 1; }'"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,8 +20,15 @@ jobs:
 
       - name: Stripe legacy API guard
         run: |
-          if grep -RnE --include='*.go' --exclude-dir=vendor 'stripe[A-Za-z0-9_]*\.Key\b|stripe-go/v82/(paymentintent|customer)\b' .; then
+          status=0
+          matches=$(grep -RnE --include='*.go' --exclude-dir=vendor 'stripe[A-Za-z0-9_]*\.Key\b|stripe-go/v82/(paymentintent|customer)\b' .) || status=$?
+          if [ "$status" -gt 1 ]; then
+            echo "Unable to scan Go sources for legacy stripe-go API usage"
+            exit 1
+          fi
+          if [ -n "$matches" ]; then
             echo "Legacy stripe-go API usage found: use stripe.Client via appconfig.GetStripeClientByCurrency"
+            echo "$matches"
             exit 1
           fi
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Stripe legacy API guard
         run: |
-          if grep -RnE --include='*.go' --exclude-dir=vendor 'stripe\.Key|stripe-go/v82/(paymentintent|customer)\b' .; then
+          if grep -RnE --include='*.go' --exclude-dir=vendor 'stripe[A-Za-z0-9_]*\.Key\b|stripe-go/v82/(paymentintent|customer)\b' .; then
             echo "Legacy stripe-go API usage found: use stripe.Client via appconfig.GetStripeClientByCurrency"
             exit 1
           fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Stripe legacy API guard
+        run: |
+          if grep -RnE --include='*.go' --exclude-dir=vendor 'stripe\.Key|stripe-go/v82/(paymentintent|customer)\b' .; then
+            echo "Legacy stripe-go API usage found: use stripe.Client via appconfig.GetStripeClientByCurrency"
+            exit 1
+          fi
+
       - name: Swagger - Installation
         run: go install github.com/swaggo/swag/cmd/swag@latest
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ go run main.go -config=config.json
     1) Yes, cancel the intent
     2) No, capture the intent
 
+## Stripe client
+
+All Stripe calls go through a per-currency client built by
+`appconfig.GetStripeClientByCurrency` (the stripe-go `stripe.Client` API), so
+the secret key is bound to the client instead of shared global state. The
+deprecated global key (`stripe.Key`) and the legacy resource packages
+(`stripe-go/v82/paymentintent`, `stripe-go/v82/customer`) must not be used:
+the pre-commit hook and CI reject them.
+
 ## Tests
 
 ```bash

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -110,6 +110,50 @@ func TestLowercaseCurrencyStripeAPIConfig(t *testing.T) {
 	}
 }
 
+func TestStripeClientByCurrency(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	sc, e := appconfig.GetStripeClientByCurrency("EUR")
+	if e != nil {
+		t.Errorf("error during the creation of the Stripe client for EUR currency: %v", e)
+	}
+
+	if sc == nil {
+		t.Error("the Stripe client for EUR currency is nil")
+	}
+}
+
+func TestDefaultStripeClientByCurrency(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	sc, e := appconfig.GetStripeClientByCurrency("NOT_FOUND_CURRENCY")
+	if e != nil {
+		t.Errorf("error during the creation of the Stripe client for an inexistent currency: %v", e)
+	}
+
+	if sc == nil {
+		t.Error("the Stripe client for an inexistent currency does not fall back to the default keys")
+	}
+}
+
+func TestWithoutDefaultStripeClientByCurrency(t *testing.T) {
+	e := appconfig.ImportConfig(strings.NewReader(confStripeWithoutDefault))
+	if e != nil {
+		t.Errorf("error during the config import: %v", e)
+	}
+
+	_, e = appconfig.GetStripeClientByCurrency("NOT_FOUND_CURRENCY")
+	if e == nil {
+		t.Error("creating a Stripe client without default API keys must return an error")
+	}
+}
+
 func TestServerConfig(t *testing.T) {
 	e := appconfig.ImportConfig(strings.NewReader(confServer))
 	if e != nil {

--- a/config/stripe_client.go
+++ b/config/stripe_client.go
@@ -1,0 +1,18 @@
+package appconfig
+
+import (
+	"github.com/stripe/stripe-go/v82"
+)
+
+// GetStripeClientByCurrency returns a Stripe client bound to the secret key
+// configured for c currency (or the default keys if c is not configured).
+// The key is bound to the client instead of the deprecated package-level key,
+// so concurrent requests with different currencies cannot race on it.
+func GetStripeClientByCurrency(c string) (*stripe.Client, error) {
+	sck, e := GetStripeAPIConfigByCurrency(c)
+	if e != nil {
+		return nil, e
+	}
+
+	return stripe.NewClient(sck.GetSK()), nil
+}

--- a/config/stripe_client.go
+++ b/config/stripe_client.go
@@ -1,6 +1,8 @@
 package appconfig
 
 import (
+	"fmt"
+
 	"github.com/stripe/stripe-go/v82"
 )
 
@@ -11,7 +13,7 @@ import (
 func GetStripeClientByCurrency(c string) (*stripe.Client, error) {
 	sck, e := GetStripeAPIConfigByCurrency(c)
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe API configuration for %v currency: %w", c, e)
 	}
 
 	return stripe.NewClient(sck.GetSK()), nil

--- a/controller/rest/intent/cancel/restintentcancel_integration_test.go
+++ b/controller/rest/intent/cancel/restintentcancel_integration_test.go
@@ -93,9 +93,7 @@ func Test(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent("EUR", intentID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, "EUR", intentID)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))

--- a/controller/rest/intent/cancel/restintentcancel_integration_test.go
+++ b/controller/rest/intent/cancel/restintentcancel_integration_test.go
@@ -81,7 +81,7 @@ func createTestIntent() (string, error) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("impossible to create a new payment intent for testing: %w", e)
 	}
 
 	return intent.ID, e
@@ -91,8 +91,11 @@ func createTestIntent() (string, error) {
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent("EUR", intentID)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -121,6 +124,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "canceled" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'canceled'")
 	}
-
-	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/cancel/restintentcancel_integration_test.go
+++ b/controller/rest/intent/cancel/restintentcancel_integration_test.go
@@ -18,10 +18,10 @@ import (
 	appconfig "github.com/lelledev/upaygo/config"
 	apprestintentcancel "github.com/lelledev/upaygo/controller/rest/intent/cancel"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,7 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -125,5 +122,5 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'canceled'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/capture/restintentcapture_integration_test.go
+++ b/controller/rest/intent/capture/restintentcapture_integration_test.go
@@ -81,7 +81,7 @@ func createTestIntent() (string, error) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("impossible to create a new payment intent for testing: %w", e)
 	}
 
 	return intent.ID, e
@@ -91,8 +91,11 @@ func createTestIntent() (string, error) {
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent("EUR", intentID)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -121,6 +124,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "succeeded" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'succeeded'")
 	}
-
-	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/capture/restintentcapture_integration_test.go
+++ b/controller/rest/intent/capture/restintentcapture_integration_test.go
@@ -93,9 +93,7 @@ func Test(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent("EUR", intentID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, "EUR", intentID)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))

--- a/controller/rest/intent/capture/restintentcapture_integration_test.go
+++ b/controller/rest/intent/capture/restintentcapture_integration_test.go
@@ -18,10 +18,10 @@ import (
 	appconfig "github.com/lelledev/upaygo/config"
 	apprestintentcapture "github.com/lelledev/upaygo/controller/rest/intent/capture"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(1179)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,7 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -125,5 +122,5 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status 'succeeded'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/confirm/restintentconfirm_integration_test.go
+++ b/controller/rest/intent/confirm/restintentconfirm_integration_test.go
@@ -92,9 +92,7 @@ func Test(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent("EUR", intentID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, "EUR", intentID)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))

--- a/controller/rest/intent/confirm/restintentconfirm_integration_test.go
+++ b/controller/rest/intent/confirm/restintentconfirm_integration_test.go
@@ -18,10 +18,10 @@ import (
 	appconfig "github.com/lelledev/upaygo/config"
 	apprestintentconfirm "github.com/lelledev/upaygo/controller/rest/intent/confirm"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -78,10 +78,7 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -124,5 +121,5 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status as 'requires_capture'")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/confirm/restintentconfirm_integration_test.go
+++ b/controller/rest/intent/confirm/restintentconfirm_integration_test.go
@@ -80,7 +80,7 @@ func createTestIntent() (string, error) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("impossible to create a new payment intent for testing: %w", e)
 	}
 
 	return intent.ID, e
@@ -90,8 +90,11 @@ func createTestIntent() (string, error) {
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent("EUR", intentID)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", strings.NewReader("currency=EUR"))
@@ -120,6 +123,4 @@ func Test(t *testing.T) {
 	if resI.Status.R != "requires_capture" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the status as 'requires_capture'")
 	}
-
-	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -92,11 +92,7 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, e)
 	}
 
-	if resI.IntentGatewayReference != "" {
-		t.Cleanup(func() {
-			appstripetest.CancelIntent(c.GetISO4217(), resI.IntentGatewayReference)
-		})
-	}
+	appstripetest.CleanupIntentIfCreated(t, c.GetISO4217(), resI.IntentGatewayReference)
 
 	if resI.IntentGatewayReference == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
@@ -131,11 +127,7 @@ func TestWithoutCustomer(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, e)
 	}
 
-	if resI.IntentGatewayReference != "" {
-		t.Cleanup(func() {
-			appstripetest.CancelIntent(c, resI.IntentGatewayReference)
-		})
-	}
+	appstripetest.CleanupIntentIfCreated(t, c, resI.IntentGatewayReference)
 
 	if resI.IntentGatewayReference == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -14,12 +14,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stripe/stripe-go/v82/customer"
-
 	appconfig "github.com/lelledev/upaygo/config"
 	apprestintentcreate "github.com/lelledev/upaygo/controller/rest/intent/create"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 )
 
 const (
@@ -98,7 +97,7 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the customer reference")
 	}
 
-	_, _ = customer.Del(cus.GetGatewayReference(), nil)
+	appstripetest.DeleteCustomer(c.GetISO4217(), cus.GetGatewayReference())
 }
 
 // Test a create intent request without customer

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -67,8 +67,11 @@ func Test(t *testing.T) {
 	c, _ := appcurrency.New("EUR")
 	cus, e := appcustomer.NewStripe("email@email.com", c)
 	if e != nil {
-		t.Errorf(errorRestCreateIntent, e)
+		t.Fatalf(errorRestCreateIntent, e)
 	}
+	t.Cleanup(func() {
+		appstripetest.DeleteCustomer(c.GetISO4217(), cus.GetGatewayReference())
+	})
 
 	a, ps, w := 7777, "pm_card_visa", httptest.NewRecorder()
 	p := fmt.Sprintf("currency=%v&amount=%v&payment_source=%v&customer_reference=%v", c.GetISO4217(), a, ps, cus.GetGatewayReference())
@@ -96,8 +99,6 @@ func Test(t *testing.T) {
 	if resI.Customer.R == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the customer reference")
 	}
-
-	appstripetest.DeleteCustomer(c.GetISO4217(), cus.GetGatewayReference())
 }
 
 // Test a create intent request without customer

--- a/controller/rest/intent/create/restintentcreate_integration_test.go
+++ b/controller/rest/intent/create/restintentcreate_integration_test.go
@@ -92,6 +92,12 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, e)
 	}
 
+	if resI.IntentGatewayReference != "" {
+		t.Cleanup(func() {
+			appstripetest.CancelIntent(c.GetISO4217(), resI.IntentGatewayReference)
+		})
+	}
+
 	if resI.IntentGatewayReference == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
 	}
@@ -123,6 +129,12 @@ func TestWithoutCustomer(t *testing.T) {
 	e = json.Unmarshal(resBody, &resI)
 	if e != nil {
 		t.Errorf(errorRestCreateIntent, e)
+	}
+
+	if resI.IntentGatewayReference != "" {
+		t.Cleanup(func() {
+			appstripetest.CancelIntent(c, resI.IntentGatewayReference)
+		})
 	}
 
 	if resI.IntentGatewayReference == "" {

--- a/controller/rest/intent/get/restintentget_integration_test.go
+++ b/controller/rest/intent/get/restintentget_integration_test.go
@@ -93,9 +93,7 @@ func Test(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent("EUR", intentID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, "EUR", intentID)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)

--- a/controller/rest/intent/get/restintentget_integration_test.go
+++ b/controller/rest/intent/get/restintentget_integration_test.go
@@ -81,7 +81,7 @@ func createTestIntent() (string, error) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
+		return "", fmt.Errorf("impossible to create a new payment intent for testing: %w", e)
 	}
 
 	return intent.ID, e
@@ -91,8 +91,11 @@ func createTestIntent() (string, error) {
 func Test(t *testing.T) {
 	intentID, e := createTestIntent()
 	if e != nil {
-		t.Error(e.Error())
+		t.Fatal(e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent("EUR", intentID)
+	})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
@@ -120,6 +123,4 @@ func Test(t *testing.T) {
 	if resI.IntentGatewayReference == "" {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
 	}
-
-	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/controller/rest/intent/get/restintentget_integration_test.go
+++ b/controller/rest/intent/get/restintentget_integration_test.go
@@ -18,10 +18,10 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 
 	"github.com/gorilla/mux"
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 const (
@@ -66,7 +66,7 @@ func TestMain(m *testing.M) {
 func createTestIntent() (string, error) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(4567)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		PaymentMethod:      new("pm_card_visa"),
@@ -79,10 +79,7 @@ func createTestIntent() (string, error) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		return "", fmt.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -124,5 +121,5 @@ func Test(t *testing.T) {
 		t.Errorf(errorRestCreateIntent, "the body response does not have the gateway reference")
 	}
 
-	_, _ = paymentintent.Cancel(intentID, nil)
+	appstripetest.CancelIntent("EUR", intentID)
 }

--- a/customer/customerstripe.go
+++ b/customer/customerstripe.go
@@ -1,11 +1,10 @@
 package appcustomer
 
 import (
+	"context"
 	"errors"
 
 	apperror "github.com/lelledev/upaygo/error"
-
-	"github.com/stripe/stripe-go/v82/customer"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,17 +17,15 @@ func NewStripe(email string, ac appcurrency.Currency) (Customer, error) {
 		return nil, errors.New("impossible to create a Stripe customer without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(ac.GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(ac.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	params := &stripe.CustomerParams{
+	params := &stripe.CustomerCreateParams{
 		Email: new(email),
 	}
-	cus, e := customer.New(params)
+	cus, e := sc.V1Customers.Create(context.Background(), params)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/customer/customerstripe.go
+++ b/customer/customerstripe.go
@@ -3,6 +3,7 @@ package appcustomer
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	apperror "github.com/lelledev/upaygo/error"
 
@@ -19,7 +20,7 @@ func NewStripe(email string, ac appcurrency.Currency) (Customer, error) {
 
 	sc, e := appconfig.GetStripeClientByCurrency(ac.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to create the customer: %w", e)
 	}
 
 	params := &stripe.CustomerCreateParams{

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -9,12 +9,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stripe/stripe-go/v82/customer"
-
 	appcurrency "github.com/lelledev/upaygo/currency"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 )
 
 func TestMain(m *testing.M) {
@@ -60,5 +59,5 @@ func TestNewStripe(t *testing.T) {
 		t.Errorf("The new customer.email is incorrect, got: %v want %v", got.GetEmail(), email)
 	}
 
-	_, _ = customer.Del(got.GetGatewayReference(), nil)
+	appstripetest.DeleteCustomer(c.GetISO4217(), got.GetGatewayReference())
 }

--- a/customer/customerstripe_integration_test.go
+++ b/customer/customerstripe_integration_test.go
@@ -48,8 +48,11 @@ func TestNewStripe(t *testing.T) {
 
 	got, e := appcustomer.NewStripe(email, c)
 	if e != nil {
-		t.Errorf("error during the appcustomer creation with Stripe: %v", e)
+		t.Fatalf("error during the appcustomer creation with Stripe: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.DeleteCustomer(c.GetISO4217(), got.GetGatewayReference())
+	})
 
 	if got.GetGatewayReference() == "" {
 		t.Errorf("The new customer.gateway_reference is empty, got: %v", got.GetGatewayReference())
@@ -58,6 +61,4 @@ func TestNewStripe(t *testing.T) {
 	if got.GetEmail() != email {
 		t.Errorf("The new customer.email is incorrect, got: %v want %v", got.GetEmail(), email)
 	}
-
-	appstripetest.DeleteCustomer(c.GetISO4217(), got.GetGatewayReference())
 }

--- a/internal/stripetest/stripetest.go
+++ b/internal/stripetest/stripetest.go
@@ -7,6 +7,7 @@ package appstripetest
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	appconfig "github.com/lelledev/upaygo/config"
 
@@ -26,6 +27,18 @@ func NewIntent(c string, params *stripe.PaymentIntentCreateParams) (*stripe.Paym
 	}
 
 	return intent, nil
+}
+
+// CleanupIntentIfCreated registers a t.Cleanup that cancels the id payment
+// intent on the c currency Stripe account; it does nothing if id is empty
+func CleanupIntentIfCreated(t *testing.T, c string, id string) {
+	if id == "" {
+		return
+	}
+
+	t.Cleanup(func() {
+		CancelIntent(c, id)
+	})
 }
 
 // CancelIntent cancels the id payment intent on the c currency Stripe account,

--- a/internal/stripetest/stripetest.go
+++ b/internal/stripetest/stripetest.go
@@ -1,0 +1,45 @@
+// Package appstripetest provides shared Stripe fixtures for integration tests:
+// create a payment intent for a test, cancel it and delete customers as
+// best-effort cleanup. It goes through the same per-currency stripe.Client
+// used by production code, so tests never touch the deprecated package-level key.
+package appstripetest
+
+import (
+	"context"
+
+	appconfig "github.com/lelledev/upaygo/config"
+
+	"github.com/stripe/stripe-go/v82"
+)
+
+// NewIntent creates a payment intent on the c currency Stripe account
+func NewIntent(c string, params *stripe.PaymentIntentCreateParams) (*stripe.PaymentIntent, error) {
+	sc, e := appconfig.GetStripeClientByCurrency(c)
+	if e != nil {
+		return nil, e
+	}
+
+	return sc.V1PaymentIntents.Create(context.Background(), params)
+}
+
+// CancelIntent cancels the id payment intent on the c currency Stripe account,
+// ignoring errors (best-effort cleanup)
+func CancelIntent(c string, id string) {
+	sc, e := appconfig.GetStripeClientByCurrency(c)
+	if e != nil {
+		return
+	}
+
+	_, _ = sc.V1PaymentIntents.Cancel(context.Background(), id, nil)
+}
+
+// DeleteCustomer deletes the id customer on the c currency Stripe account,
+// ignoring errors (best-effort cleanup)
+func DeleteCustomer(c string, id string) {
+	sc, e := appconfig.GetStripeClientByCurrency(c)
+	if e != nil {
+		return
+	}
+
+	_, _ = sc.V1Customers.Delete(context.Background(), id, nil)
+}

--- a/internal/stripetest/stripetest.go
+++ b/internal/stripetest/stripetest.go
@@ -6,6 +6,7 @@ package appstripetest
 
 import (
 	"context"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 
@@ -19,7 +20,12 @@ func NewIntent(c string, params *stripe.PaymentIntentCreateParams) (*stripe.Paym
 		return nil, e
 	}
 
-	return sc.V1PaymentIntents.Create(context.Background(), params)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), params)
+	if e != nil {
+		return nil, fmt.Errorf("impossible to create the payment intent fixture for %v currency: %w", c, e)
+	}
+
+	return intent, nil
 }
 
 // CancelIntent cancels the id payment intent on the c currency Stripe account,

--- a/payment/intent/cancel/intentcancel.go
+++ b/payment/intent/cancel/intentcancel.go
@@ -1,15 +1,13 @@
 package apppaymentintentcancel
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Cancel gets the intent id from c Stripe account and cancel it
@@ -18,14 +16,12 @@ func Cancel(id string, c appcurrency.Currency) (apppaymentintent.Intent, error) 
 		return nil, errors.New("impossible to cancel the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Cancel(id, nil)
+	intent, e := sc.V1PaymentIntents.Cancel(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/cancel/intentcancel.go
+++ b/payment/intent/cancel/intentcancel.go
@@ -3,6 +3,7 @@ package apppaymentintentcancel
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,7 +19,7 @@ func Cancel(id string, c appcurrency.Currency) (apppaymentintent.Intent, error) 
 
 	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to cancel the payment intent: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Cancel(context.Background(), id, nil)

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -11,10 +11,10 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcancel "github.com/lelledev/upaygo/payment/intent/cancel"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestCancel(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -58,10 +58,7 @@ func TestCancel(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -79,7 +76,7 @@ func TestCancel(t *testing.T) {
 func TestCancelWithSCACard(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -91,10 +88,7 @@ func TestCancelWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -112,7 +106,7 @@ func TestCancelWithSCACard(t *testing.T) {
 func TestCancelNonConfirmedIntent(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("manual"),
@@ -124,10 +118,7 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -44,101 +44,48 @@ func TestMain(m *testing.M) {
 }
 
 func TestCancel(t *testing.T) {
-	cur, _ := appcurrency.New("EUR")
-	am := int64(2088)
-	pip := &stripe.PaymentIntentCreateParams{
-		Amount:             new(am),
-		Currency:           new(cur.GetISO4217()),
-		ConfirmationMethod: new("automatic"),
-		Confirm:            new(true),
-		CaptureMethod:      new("manual"),
-		PaymentMethod:      new("pm_card_visa"),
-		// payment_method_types is compatible with confirmation_method;
-		// automatic_payment_methods is not (Stripe rejects both together).
-		PaymentMethodTypes: []*string{new("card")},
+	tests := []struct {
+		name               string
+		confirmationMethod string
+		confirm            bool
+		paymentMethod      string
+	}{
+		{"ConfirmedIntent", "automatic", true, "pm_card_visa"},
+		{"SCACard", "automatic", true, "pm_card_authenticationRequiredOnSetup"},
+		{"NonConfirmedIntent", "manual", false, "pm_card_authenticationRequiredOnSetup"},
 	}
 
-	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
-	if e != nil {
-		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
-	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cur, _ := appcurrency.New("EUR")
+			am := int64(2088)
+			pip := &stripe.PaymentIntentCreateParams{
+				Amount:             new(am),
+				Currency:           new(cur.GetISO4217()),
+				ConfirmationMethod: new(tc.confirmationMethod),
+				Confirm:            new(tc.confirm),
+				CaptureMethod:      new("manual"),
+				PaymentMethod:      new(tc.paymentMethod),
+				// payment_method_types is compatible with confirmation_method;
+				// automatic_payment_methods is not (Stripe rejects both together).
+				PaymentMethodTypes: []*string{new("card")},
+			}
 
-	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
-	if e != nil {
-		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
-	}
+			intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
+			if e != nil {
+				t.Fatalf("impossible to create a new payment intent for testing: %v", e)
+			}
+			appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), intent.ID)
 
-	if !appintent.IsCanceled() {
-		t.Error("intent cancel is incorrect, got an intent that is not canceled")
-	}
-}
+			appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
+			if e != nil {
+				t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
+			}
 
-func TestCancelWithSCACard(t *testing.T) {
-	cur, _ := appcurrency.New("EUR")
-	am := int64(2088)
-	pip := &stripe.PaymentIntentCreateParams{
-		Amount:             new(am),
-		Currency:           new(cur.GetISO4217()),
-		ConfirmationMethod: new("automatic"),
-		Confirm:            new(true),
-		CaptureMethod:      new("manual"),
-		PaymentMethod:      new("pm_card_authenticationRequiredOnSetup"),
-		// payment_method_types is compatible with confirmation_method;
-		// automatic_payment_methods is not (Stripe rejects both together).
-		PaymentMethodTypes: []*string{new("card")},
-	}
-
-	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
-	if e != nil {
-		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
-	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
-
-	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
-	if e != nil {
-		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
-	}
-
-	if !appintent.IsCanceled() {
-		t.Error("intent cancel is incorrect, got an intent that is not canceled")
-	}
-}
-
-func TestCancelNonConfirmedIntent(t *testing.T) {
-	cur, _ := appcurrency.New("EUR")
-	am := int64(2088)
-	pip := &stripe.PaymentIntentCreateParams{
-		Amount:             new(am),
-		Currency:           new(cur.GetISO4217()),
-		ConfirmationMethod: new("manual"),
-		Confirm:            new(false),
-		CaptureMethod:      new("manual"),
-		PaymentMethod:      new("pm_card_authenticationRequiredOnSetup"),
-		// payment_method_types is compatible with confirmation_method;
-		// automatic_payment_methods is not (Stripe rejects both together).
-		PaymentMethodTypes: []*string{new("card")},
-	}
-
-	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
-	if e != nil {
-		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
-	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
-
-	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
-	if e != nil {
-		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
-	}
-
-	if !appintent.IsCanceled() {
-		t.Error("intent cancel is incorrect, got an intent that is not canceled")
+			if !appintent.IsCanceled() {
+				t.Error("intent cancel is incorrect, got an intent that is not canceled")
+			}
+		})
 	}
 }
 

--- a/payment/intent/cancel/intentcancel_integration_test.go
+++ b/payment/intent/cancel/intentcancel_integration_test.go
@@ -60,12 +60,15 @@ func TestCancel(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {
@@ -90,12 +93,15 @@ func TestCancelWithSCACard(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {
@@ -120,12 +126,15 @@ func TestCancelNonConfirmedIntent(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentcancel.Cancel(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to cancel %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to cancel %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsCanceled() {

--- a/payment/intent/capture/intentcapture.go
+++ b/payment/intent/capture/intentcapture.go
@@ -1,15 +1,13 @@
 package apppaymentintentcapture
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Capture gets the intent id from c Stripe account and capture it
@@ -18,14 +16,12 @@ func Capture(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to capture the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Capture(id, nil)
+	intent, e := sc.V1PaymentIntents.Capture(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/capture/intentcapture.go
+++ b/payment/intent/capture/intentcapture.go
@@ -3,6 +3,7 @@ package apppaymentintentcapture
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,7 +19,7 @@ func Capture(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 
 	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to capture the payment intent: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Capture(context.Background(), id, nil)

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -62,9 +62,7 @@ func TestCapture(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), intent.ID)
 
 	appintent, e := apppaymentintentcapture.Capture(intent.ID, cur)
 	if e != nil {
@@ -95,9 +93,7 @@ func TestCaptureWithSCACard(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), intent.ID)
 
 	_, e = apppaymentintentcapture.Capture(intent.ID, cur)
 	if e == nil {

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -11,10 +11,10 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcapture "github.com/lelledev/upaygo/payment/intent/capture"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestCapture(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -58,10 +58,7 @@ func TestCapture(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -75,13 +72,13 @@ func TestCapture(t *testing.T) {
 		t.Error("intent capture is incorrect, got an intent that is not succeeded")
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestCaptureWithSCACard(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("automatic"),
@@ -93,10 +90,7 @@ func TestCaptureWithSCACard(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -106,7 +100,7 @@ func TestCaptureWithSCACard(t *testing.T) {
 		t.Errorf("intent %v should not be captured as it should have status requires_action", intent.ID)
 	}
 
-	_, _ = paymentintent.Cancel(intent.ID, nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
 }
 
 func TestCaptureWithoutID(t *testing.T) {

--- a/payment/intent/capture/intentcapture_integration_test.go
+++ b/payment/intent/capture/intentcapture_integration_test.go
@@ -60,19 +60,20 @@ func TestCapture(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentcapture.Capture(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to capture %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to capture %v payment intent: %v", intent.ID, e)
 	}
 
 	if !appintent.IsSucceeded() {
 		t.Error("intent capture is incorrect, got an intent that is not succeeded")
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestCaptureWithSCACard(t *testing.T) {
@@ -92,15 +93,16 @@ func TestCaptureWithSCACard(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	_, e = apppaymentintentcapture.Capture(intent.ID, cur)
 	if e == nil {
 		t.Errorf("intent %v should not be captured as it should have status requires_action", intent.ID)
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
 }
 
 func TestCaptureWithoutID(t *testing.T) {

--- a/payment/intent/confirm/intentconfirm.go
+++ b/payment/intent/confirm/intentconfirm.go
@@ -1,15 +1,13 @@
 package apppaymentintentconfirm
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Confirm gets the intent id from c Stripe account and confirm it
@@ -18,14 +16,12 @@ func Confirm(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 		return nil, errors.New("impossible to confirm the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Confirm(id, nil)
+	intent, e := sc.V1PaymentIntents.Confirm(context.Background(), id, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/confirm/intentconfirm.go
+++ b/payment/intent/confirm/intentconfirm.go
@@ -3,6 +3,7 @@ package apppaymentintentconfirm
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,7 +19,7 @@ func Confirm(id string, c appcurrency.Currency) (apppaymentintent.Intent, error)
 
 	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to confirm the payment intent: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Confirm(context.Background(), id, nil)

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -11,10 +11,10 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentconfirm "github.com/lelledev/upaygo/payment/intent/confirm"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 func TestConfirm(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:             new(am),
 		Currency:           new(cur.GetISO4217()),
 		ConfirmationMethod: new("manual"),
@@ -56,10 +56,7 @@ func TestConfirm(t *testing.T) {
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -73,7 +70,7 @@ func TestConfirm(t *testing.T) {
 		t.Error("intent confirmation is incorrect, got an intent that requires confirmation")
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestConfirmWithoutID(t *testing.T) {

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -58,19 +58,20 @@ func TestConfirm(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentconfirm.Confirm(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to confirm %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to confirm %v payment intent: %v", intent.ID, e)
 	}
 
 	if appintent.RequiresConfirmation() {
 		t.Error("intent confirmation is incorrect, got an intent that requires confirmation")
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestConfirmWithoutID(t *testing.T) {

--- a/payment/intent/confirm/intentconfirm_integration_test.go
+++ b/payment/intent/confirm/intentconfirm_integration_test.go
@@ -60,9 +60,7 @@ func TestConfirm(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), intent.ID)
 
 	appintent, e := apppaymentintentconfirm.Confirm(intent.ID, cur)
 	if e != nil {

--- a/payment/intent/create/intentcreate.go
+++ b/payment/intent/create/intentcreate.go
@@ -3,6 +3,7 @@ package apppaymentintentcreate
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appamount "github.com/lelledev/upaygo/amount"
 	appconfig "github.com/lelledev/upaygo/config"
@@ -22,7 +23,7 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 
 	sc, e := appconfig.GetStripeClientByCurrency(a.GetCurrency().GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to create the payment intent: %w", e)
 	}
 
 	ic := &stripe.PaymentIntentCreateParams{

--- a/payment/intent/create/intentcreate.go
+++ b/payment/intent/create/intentcreate.go
@@ -1,6 +1,7 @@
 package apppaymentintentcreate
 
 import (
+	"context"
 	"errors"
 
 	appamount "github.com/lelledev/upaygo/amount"
@@ -11,7 +12,6 @@ import (
 	apppaymentsource "github.com/lelledev/upaygo/payment/source"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Create creates an intent in Stripe and returns it as an instance of Intent
@@ -20,14 +20,12 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 		return nil, errors.New("impossible to create a payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(a.GetCurrency().GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(a.GetCurrency().GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	ic := &stripe.PaymentIntentParams{
+	ic := &stripe.PaymentIntentCreateParams{
 		Amount:             new(int64(a.GetAmount())),
 		Currency:           new(a.GetCurrency().GetISO4217()),
 		PaymentMethod:      new(p.GetGatewayReference()),
@@ -46,7 +44,7 @@ func Create(a appamount.Amount, p apppaymentsource.Source, c appcustomer.Custome
 		ic.Customer = new(c.GetGatewayReference())
 	}
 
-	intent, e := paymentintent.New(ic)
+	intent, e := sc.V1PaymentIntents.Create(context.Background(), ic)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -47,14 +47,24 @@ func TestMain(m *testing.M) {
 func TestCreate(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := 2045
-	cus, _ := appcustomer.NewStripe("email@email.com", cur)
+	cus, e := appcustomer.NewStripe("email@email.com", cur)
+	if e != nil {
+		t.Fatalf("impossible to create a customer for testing: %v", e)
+	}
+	t.Cleanup(func() {
+		appstripetest.DeleteCustomer(cur.GetISO4217(), cus.GetGatewayReference())
+	})
+
 	a, _ := appamount.New(am, cur.GetISO4217())
 	ps := apppaymentsource.New("pm_card_visa")
 
 	pi, e := apppaymentintentcreate.Create(a, ps, cus)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent: %v", e)
+		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
+	})
 
 	if pi.GetGatewayReference() == "" {
 		t.Error("intent new is incorrect, created an intent without gateway reference")
@@ -103,9 +113,6 @@ func TestCreate(t *testing.T) {
 	if !pi.RequiresConfirmation() {
 		t.Error("a new intent should require confirmation")
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
-	appstripetest.DeleteCustomer(cur.GetISO4217(), cus.GetGatewayReference())
 }
 
 func TestCreateWithoutCustomer(t *testing.T) {
@@ -116,14 +123,15 @@ func TestCreateWithoutCustomer(t *testing.T) {
 
 	pi, e := apppaymentintentcreate.Create(a, ps, nil)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent: %v", e)
+		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
+	})
 
 	if pi.GetCustomer() != nil {
 		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
 }
 
 func TestCreateWithoutAmount(t *testing.T) {

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -62,9 +62,7 @@ func TestCreate(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), pi.GetGatewayReference())
 
 	if pi.GetGatewayReference() == "" {
 		t.Error("intent new is incorrect, created an intent without gateway reference")
@@ -125,9 +123,7 @@ func TestCreateWithoutCustomer(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), pi.GetGatewayReference())
 
 	if pi.GetCustomer() != nil {
 		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())

--- a/payment/intent/create/intentcreate_integration_test.go
+++ b/payment/intent/create/intentcreate_integration_test.go
@@ -13,11 +13,9 @@ import (
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	appcustomer "github.com/lelledev/upaygo/customer"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentcreate "github.com/lelledev/upaygo/payment/intent/create"
 	apppaymentsource "github.com/lelledev/upaygo/payment/source"
-
-	"github.com/stripe/stripe-go/v82/customer"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -106,8 +104,8 @@ func TestCreate(t *testing.T) {
 		t.Error("a new intent should require confirmation")
 	}
 
-	_, _ = paymentintent.Cancel(pi.GetGatewayReference(), nil)
-	_, _ = customer.Del(cus.GetGatewayReference(), nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
+	appstripetest.DeleteCustomer(cur.GetISO4217(), cus.GetGatewayReference())
 }
 
 func TestCreateWithoutCustomer(t *testing.T) {
@@ -125,7 +123,7 @@ func TestCreateWithoutCustomer(t *testing.T) {
 		t.Errorf("intent customer should be blank, got: %v", pi.GetCustomer())
 	}
 
-	_, _ = paymentintent.Cancel(pi.GetGatewayReference(), nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), pi.GetGatewayReference())
 }
 
 func TestCreateWithoutAmount(t *testing.T) {

--- a/payment/intent/get/intentget.go
+++ b/payment/intent/get/intentget.go
@@ -1,15 +1,13 @@
 package apppaymentintentget
 
 import (
+	"context"
 	"errors"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
 	apperror "github.com/lelledev/upaygo/error"
 	apppaymentintent "github.com/lelledev/upaygo/payment/intent"
-
-	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 // Get gets the gf intent from c Stripe account and returns it as an instance of i
@@ -18,14 +16,12 @@ func Get(gf string, c appcurrency.Currency) (apppaymentintent.Intent, error) {
 		return nil, errors.New("impossible to get the payment intent without required parameters")
 	}
 
-	sck, e := appconfig.GetStripeAPIConfigByCurrency(c.GetISO4217())
+	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
 		return nil, e
 	}
 
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.Get(gf, nil)
+	intent, e := sc.V1PaymentIntents.Retrieve(context.Background(), gf, nil)
 	if e != nil {
 		m, es := apperror.GetStripeErrorMessage(e)
 		if es == nil {

--- a/payment/intent/get/intentget.go
+++ b/payment/intent/get/intentget.go
@@ -3,6 +3,7 @@ package apppaymentintentget
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
@@ -18,7 +19,7 @@ func Get(gf string, c appcurrency.Currency) (apppaymentintent.Intent, error) {
 
 	sc, e := appconfig.GetStripeClientByCurrency(c.GetISO4217())
 	if e != nil {
-		return nil, e
+		return nil, fmt.Errorf("impossible to get the Stripe client to get the payment intent: %w", e)
 	}
 
 	intent, e := sc.V1PaymentIntents.Retrieve(context.Background(), gf, nil)

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -11,10 +11,10 @@ import (
 
 	appconfig "github.com/lelledev/upaygo/config"
 	appcurrency "github.com/lelledev/upaygo/currency"
+	appstripetest "github.com/lelledev/upaygo/internal/stripetest"
 	apppaymentintentget "github.com/lelledev/upaygo/payment/intent/get"
 
 	"github.com/stripe/stripe-go/v82"
-	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
 func TestMain(m *testing.M) {
@@ -46,17 +46,14 @@ func TestMain(m *testing.M) {
 func TestGet(t *testing.T) {
 	cur, _ := appcurrency.New("EUR")
 	am := int64(2088)
-	pip := &stripe.PaymentIntentParams{
+	pip := &stripe.PaymentIntentCreateParams{
 		Amount:   new(am),
 		Currency: new(cur.GetISO4217()),
 		// Restrict to card so Dashboard redirect methods are not enabled.
 		PaymentMethodTypes: []*string{new("card")},
 	}
 
-	sck, _ := appconfig.GetStripeAPIConfigByCurrency(cur.GetISO4217())
-	stripe.Key = sck.GetSK()
-
-	intent, e := paymentintent.New(pip)
+	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
 		t.Errorf("impossible to create a new payment intent for testing: %v", e)
 	}
@@ -70,7 +67,7 @@ func TestGet(t *testing.T) {
 		t.Errorf("intent get is incorrect, got an intent with different ID. Got: %v want: %v", appintent.GetGatewayReference(), intent.ID)
 	}
 
-	_, _ = paymentintent.Cancel(appintent.GetGatewayReference(), nil)
+	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestGetWithoutID(t *testing.T) {

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -55,19 +55,20 @@ func TestGet(t *testing.T) {
 
 	intent, e := appstripetest.NewIntent(cur.GetISO4217(), pip)
 	if e != nil {
-		t.Errorf("impossible to create a new payment intent for testing: %v", e)
+		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
+	t.Cleanup(func() {
+		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
+	})
 
 	appintent, e := apppaymentintentget.Get(intent.ID, cur)
 	if e != nil {
-		t.Errorf("impossible to get %v payment intent: %v", intent.ID, e)
+		t.Fatalf("impossible to get %v payment intent: %v", intent.ID, e)
 	}
 
 	if appintent.GetGatewayReference() != intent.ID {
 		t.Errorf("intent get is incorrect, got an intent with different ID. Got: %v want: %v", appintent.GetGatewayReference(), intent.ID)
 	}
-
-	appstripetest.CancelIntent(cur.GetISO4217(), appintent.GetGatewayReference())
 }
 
 func TestGetWithoutID(t *testing.T) {

--- a/payment/intent/get/intentget_integration_test.go
+++ b/payment/intent/get/intentget_integration_test.go
@@ -57,9 +57,7 @@ func TestGet(t *testing.T) {
 	if e != nil {
 		t.Fatalf("impossible to create a new payment intent for testing: %v", e)
 	}
-	t.Cleanup(func() {
-		appstripetest.CancelIntent(cur.GetISO4217(), intent.ID)
-	})
+	appstripetest.CleanupIntentIfCreated(t, cur.GetISO4217(), intent.ID)
 
 	appintent, e := apppaymentintentget.Get(intent.ID, cur)
 	if e != nil {


### PR DESCRIPTION
Closes #51

Migrates all first-party Stripe usage from the deprecated resource-pattern APIs (`stripe.Key` global + `paymentintent.*` / `customer.*` package helpers) to the `stripe.Client` API, staying on `stripe-go/v82` (v82.5.1) as scoped in the issue. This is the "factory + all production + tests in one PR" sizing the issue suggests, plus the guardrails.

## Production changes

- **New client factory** `appconfig.GetStripeClientByCurrency(c)` (`config/stripe_client.go`): looks up the per-currency secret key via the existing `GetStripeAPIConfigByCurrency` and returns `stripe.NewClient(sk)`. Binding the key to the client fixes the race on the global `stripe.Key` under concurrent multi-currency requests — the main behavioral win.
- **Migrated call sites** (exported signatures unchanged; `context.Background()` at the payment-package boundary per the issue's phase 1, so REST handlers are untouched):

| File | Before | After |
|------|--------|-------|
| `customer/customerstripe.go` | `customer.New` | `sc.V1Customers.Create` + `CustomerCreateParams` |
| `payment/intent/create` | `paymentintent.New` | `sc.V1PaymentIntents.Create` + `PaymentIntentCreateParams` |
| `payment/intent/get` | `paymentintent.Get` | `sc.V1PaymentIntents.Retrieve` |
| `payment/intent/confirm` | `paymentintent.Confirm` | `sc.V1PaymentIntents.Confirm` |
| `payment/intent/capture` | `paymentintent.Capture` | `sc.V1PaymentIntents.Capture` |
| `payment/intent/cancel` | `paymentintent.Cancel` | `sc.V1PaymentIntents.Cancel` |

All params keep the exact same fields (including `payment_method_types: ["card"]` instead of `automatic_payment_methods`, preserving the v82 upgrade constraint). `error/stripe.go` and `payment/intent/stripeconv.go` are unaffected: the client API returns the same `*stripe.Error` / `stripe.PaymentIntent` types.

## Tests

- **Shared fixture helper** `internal/stripetest` (issue's PR 3): `NewIntent`, `CancelIntent`, `DeleteCustomer` build the per-currency client internally, so the 11 integration-test files no longer duplicate the key-lookup/`stripe.Key` dance; fixture params moved to `PaymentIntentCreateParams`.
- **New unit tests** for the factory in `config/config_test.go`: known currency, default-key fallback, and error when no default keys are configured.

## Guardrails (issue's PR 4)

- CI step in `.github/workflows/go.yml` and a `stripe-legacy-api` pre-commit hook in `.github/hooks/gitconfig`, both failing on any first-party `stripe.Key` usage or import of `stripe-go/v82/paymentintent` / `stripe-go/v82/customer` (verified the hook passes on this tree and fails on a planted violation).
- Short "Stripe client" section in the README documenting the pattern.

## Verification

- `go build ./...`, `go vet ./...` plus `go vet -tags=unit ./...` and `go vet -tags=stripe ./...` (type-checks all integration tests against the new API) — clean
- `go test ./... -failfast -tags=unit` — pass
- `gofmt -l` — clean; legacy-API guard grep — clean
- `go test ./... -tags=stripe` needs real test keys, so it runs in CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVHVXnwe4N8TnJC55c2mac

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVHVXnwe4N8TnJC55c2mac)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added currency-scoped Stripe client handling for Payment Intents and customer creation.
* **Bug Fixes**
  * Stripe operations now consistently use the currency-scoped client, with clearer errors when Stripe client/config can’t be resolved.
* **Documentation**
  * Added a “Stripe client” section and guidance to avoid deprecated legacy/global Stripe API usage.
* **Tests**
  * Refactored Stripe integration tests to centralise Payment Intent/customer lifecycle management and improved teardown.
  * Added unit tests for `GetStripeClientByCurrency` scenarios.
* **Chores**
  * Added pre-commit and CI guards that reject legacy Stripe API patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->